### PR TITLE
Fixes potential out of range error that can occur if thanos receive endpoints don't have ips set.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
   - ireturn
   - varnamelen
   - paralleltest
+  - gocognit
 
 linters-settings:
   errcheck:

--- a/main.go
+++ b/main.go
@@ -576,8 +576,10 @@ func (c *controller) sync(ctx context.Context) {
 			continue
 		}
 
-		for _, obj := range end.Subsets[0].Addresses {
-			hostNames[hashring] = append(hostNames[hashring], obj.Hostname)
+		if len(end.Subsets) > 0 {
+			for _, obj := range end.Subsets[0].Addresses {
+				hostNames[hashring] = append(hostNames[hashring], obj.Hostname)
+			}
 		}
 	}
 


### PR DESCRIPTION
**Fixes potential out of range error**

Ensure that ip addresses are set on endpoints so we don't try accessing an address on the endpoint that does not exist.
